### PR TITLE
Change BoldBlack Color to Avoid Overlap by Background Color

### DIFF
--- a/.minttyrc.dracula
+++ b/.minttyrc.dracula
@@ -1,7 +1,7 @@
 ForegroundColour=248,248,242
 BackgroundColour=40,42,54
 Black=0,0,0
-BoldBlack=40,42,53
+BoldBlack=104,104,104
 Red=255,85,85
 BoldRed=255,110,103
 Green=80,250,123


### PR DESCRIPTION
1. The BoldBlack color is so close to background color, zsh plugin zsh-autosuggestions highlight the
   suggestion using "fg=8" default, so the suggestion are overlaped by background and we can't see
   it. Refer to the setting of iTerm2, 104, 104, 104 is a good choice for BoldBlack.

> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

Before My Change.
![before](https://user-images.githubusercontent.com/19802523/39247311-99bf2cc2-48cb-11e8-9510-e366907b8561.PNG)

After My Change.
![after](https://user-images.githubusercontent.com/19802523/39247371-ce40017e-48cb-11e8-955b-07f5a5677f10.PNG)

